### PR TITLE
fix: add `null` as extra instead of detail

### DIFF
--- a/src/formatter/extras.ts
+++ b/src/formatter/extras.ts
@@ -34,7 +34,10 @@ class Extras {
    * @returns `true` if the key-value was valid and is added, false otherwise.
    */
   parseAndAdd(key: string, value: unknown): boolean {
-    if (typeof value === 'object' || typeof value === 'function') {
+    if (
+      (typeof value === 'object' && value !== null) ||
+      typeof value === 'function'
+    ) {
       return false;
     }
 

--- a/src/formatter/extras.unit.test.ts
+++ b/src/formatter/extras.unit.test.ts
@@ -95,6 +95,8 @@ describe('Extras', () => {
       expect(extras.extras).toHaveLength(0);
       extras.parseAndAdd('myKey', 'myValue');
       expect(extras.extras).toHaveLength(1);
+      extras.parseAndAdd('otherKey', null);
+      expect(extras.extras).toHaveLength(2);
     });
 
     it('does not add the extra if it is invalid', () => {


### PR DESCRIPTION
`null` should always have been an extra, but was not due to it being marked as an `object` type in JS/TS.
